### PR TITLE
Use `uss` to compute memory

### DIFF
--- a/rlj/judge.py
+++ b/rlj/judge.py
@@ -71,8 +71,8 @@ class Judge(object):
                                      stdout=Output, stderr=Err)
             ps = psutil.Process(child.pid)
             while child.poll() is None:
-                mem_info = ps.memory_info()
-                memory = float(mem_info.rss) / 1048576
+                mem_info = ps.memory_full_info()
+                memory = float(mem_info.uss) / 1048576
                 time_used = int((time.time() - begin_time) * 1000)
                 max_memory = max(max_memory, memory)
                 if memory > self.Memory:


### PR DESCRIPTION
According to psutil's [documentation](https://psutil.readthedocs.io/en/latest/#psutil.Process.memory_full_info), `memory_full_info().uss` would be better to determin how much memory a process used

> Note uss is probably the most representative metric for determining how much memory is actually being used by a process. It represents the amount of memory that would be freed if the process was terminated right now.